### PR TITLE
Use Long- Rather than Short-Form Commit Hash

### DIFF
--- a/packages/js-interpreter-tyrant/package.json
+++ b/packages/js-interpreter-tyrant/package.json
@@ -23,12 +23,12 @@
     "runner.js"
   ],
   "resolutions": {
-    "eshost": "github:pcardune/eshost#f3fa7fa",
+    "eshost": "github:pcardune/eshost#f3fa7fa6e553286bbc0d85d864249f48ee81d40c",
     "test262-compiler": "github:pcardune/test262-compiler#ffa0dff"
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "eshost": "github:pcardune/eshost#f3fa7fa",
+    "eshost": "github:pcardune/eshost#f3fa7fa6e553286bbc0d85d864249f48ee81d40c",
     "node-fetch": "^1.6.3",
     "progress": "^1.1.8",
     "react": "^15.6.1",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -x
 cd packages/js-interpreter-portal
 yarn install --production=false


### PR DESCRIPTION
Otherwise, we get the following error when trying to install this dependency with Yarn > 1.x:

    ➤ YN0001: │ Error: eshost@github:pcardune/eshost#f3fa7fa: Invalid commit hash

In the long run, it would be ideal to get these dependencies back on mainline, but as a short-term fix this should be quite safe.

# Testing Story

Verified with `"@code-dot-org/js-interpreter-tyrant": "code-dot-org/js-interpreter-tyrant#use-valid-commit-hash",` that with this change, we can successfully install this dependency in our main repo using Yarn 3.6.3

# Deployment Strategy

After approval and merge, I will run the following commands to publish a new 0.2.3 version which our main repo can target in order to support Yarn > 1.x:

```
npm version patch
git push
git push --tags
npm publish
```
